### PR TITLE
feat(core/ui_tweaks): multiple hide ui components

### DIFF
--- a/common/src/main/assets/lang/en_US.json
+++ b/common/src/main/assets/lang/en_US.json
@@ -1428,17 +1428,17 @@
             },
             "hide_ui_components": {
                 "hide_profile_call_buttons": "Remove Profile Call Buttons",
+                "hide_snap_create_group_buttons": "Remove Snap Create Group Buttons",
                 "hide_chat_call_buttons": "Remove Chat Call Buttons",
+                "hide_chat_camera_button": "Remove Chat Camera Button",
+                "hide_chat_gallery_button": "Remove Chat Gallery Button",
+                "hide_explorer_token_button": "Remove Explorer Token Button",
                 "hide_live_location_share_button": "Remove Live Location Share Button",
                 "hide_stickers_button": "Remove Stickers Button",
                 "hide_voice_record_button": "Remove Voice Record Button",
                 "hide_unread_chat_hint": "Remove Unread Chat Hint",
                 "hide_post_to_story_buttons": "Remove Post to Story Buttons",
-                "hide_below_header_message_banner": "Remove Reminders to gift Snapchat Plus",
-                "hide_chat_input_bar_camera": "Remove Chat Camera Icon",
-                "hide_chat_input_bar_gallery": "Remove Chat Gallery Icon",
-                "hide_send_to_recipient_bar_new_group_button": "Remove Create Group Button when sending a Snap",
-                "hide_explorer_action": "Remove Tokens Icon in Explorer"
+                "hide_gift_snapchat_plus_reminders": "Remove Gift Snapchat Plus Reminders"
             },
             "hide_story_suggestions": {
                 "hide_friend_suggestions": "Hide friend suggestions",

--- a/common/src/main/assets/lang/en_US.json
+++ b/common/src/main/assets/lang/en_US.json
@@ -1433,7 +1433,12 @@
                 "hide_stickers_button": "Remove Stickers Button",
                 "hide_voice_record_button": "Remove Voice Record Button",
                 "hide_unread_chat_hint": "Remove Unread Chat Hint",
-                "hide_post_to_story_buttons": "Remove Post to Story buttons before sending a Snap"
+                "hide_post_to_story_buttons": "Remove Post to Story Buttons before sending a Snap",
+                "hide_billboard_prompt": "Remove Home Screen Annoying Reminders",
+                "hide_below_header_message_banner": "Remove Annoying Reminders to gift Snapchat Plus",
+                "hide_chat_input_bar_camera": "Remove Chat Camera Icon",
+                "hide_chat_input_bar_gallery": "Remove Chat Gallery Icon",
+                "hide_camera_zoom_factor_pill": "Remove Camera Zoom Pill"
             },
             "hide_story_suggestions": {
                 "hide_friend_suggestions": "Hide friend suggestions",

--- a/common/src/main/assets/lang/en_US.json
+++ b/common/src/main/assets/lang/en_US.json
@@ -1438,7 +1438,7 @@
                 "hide_below_header_message_banner": "Remove Reminders to gift Snapchat Plus",
                 "hide_chat_input_bar_camera": "Remove Chat Camera Icon",
                 "hide_chat_input_bar_gallery": "Remove Chat Gallery Icon",
-                "hide_camera_zoom_factor_pill": "Remove Camera Zoom Pill"
+                "hide_send_to_recipient_bar_new_group_button": "Remove Create Group Button when sending a Snap"
             },
             "hide_story_suggestions": {
                 "hide_friend_suggestions": "Hide friend suggestions",

--- a/common/src/main/assets/lang/en_US.json
+++ b/common/src/main/assets/lang/en_US.json
@@ -1433,9 +1433,9 @@
                 "hide_stickers_button": "Remove Stickers Button",
                 "hide_voice_record_button": "Remove Voice Record Button",
                 "hide_unread_chat_hint": "Remove Unread Chat Hint",
-                "hide_post_to_story_buttons": "Remove Post to Story Buttons before sending a Snap",
-                "hide_billboard_prompt": "Remove Home Screen Annoying Reminders",
-                "hide_below_header_message_banner": "Remove Annoying Reminders to gift Snapchat Plus",
+                "hide_post_to_story_buttons": "Remove Post to Story Buttons",
+                "hide_billboard_prompt": "Remove Home Screen Reminders",
+                "hide_below_header_message_banner": "Remove Reminders to gift Snapchat Plus",
                 "hide_chat_input_bar_camera": "Remove Chat Camera Icon",
                 "hide_chat_input_bar_gallery": "Remove Chat Gallery Icon",
                 "hide_camera_zoom_factor_pill": "Remove Camera Zoom Pill"

--- a/common/src/main/assets/lang/en_US.json
+++ b/common/src/main/assets/lang/en_US.json
@@ -1434,7 +1434,6 @@
                 "hide_voice_record_button": "Remove Voice Record Button",
                 "hide_unread_chat_hint": "Remove Unread Chat Hint",
                 "hide_post_to_story_buttons": "Remove Post to Story Buttons",
-                "hide_billboard_prompt": "Remove Home Screen Reminders",
                 "hide_below_header_message_banner": "Remove Reminders to gift Snapchat Plus",
                 "hide_chat_input_bar_camera": "Remove Chat Camera Icon",
                 "hide_chat_input_bar_gallery": "Remove Chat Gallery Icon",

--- a/common/src/main/assets/lang/en_US.json
+++ b/common/src/main/assets/lang/en_US.json
@@ -1438,7 +1438,6 @@
                 "hide_chat_input_bar_camera": "Remove Chat Camera Icon",
                 "hide_chat_input_bar_gallery": "Remove Chat Gallery Icon",
                 "hide_send_to_recipient_bar_new_group_button": "Remove Create Group Button when sending a Snap",
-                "hide_ngs_spotlight_icon_container": "Remove Spotlight Icon",
                 "hide_explorer_action": "Remove Tokens Icon in Explorer"
             },
             "hide_story_suggestions": {

--- a/common/src/main/assets/lang/en_US.json
+++ b/common/src/main/assets/lang/en_US.json
@@ -1438,7 +1438,9 @@
                 "hide_below_header_message_banner": "Remove Reminders to gift Snapchat Plus",
                 "hide_chat_input_bar_camera": "Remove Chat Camera Icon",
                 "hide_chat_input_bar_gallery": "Remove Chat Gallery Icon",
-                "hide_send_to_recipient_bar_new_group_button": "Remove Create Group Button when sending a Snap"
+                "hide_send_to_recipient_bar_new_group_button": "Remove Create Group Button when sending a Snap",
+                "hide_ngs_spotlight_icon_container": "Remove Spotlight Icon",
+                "hide_explorer_action": "Remove Tokens Icon in Explorer"
             },
             "hide_story_suggestions": {
                 "hide_friend_suggestions": "Hide friend suggestions",

--- a/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/UserInterfaceTweaks.kt
+++ b/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/UserInterfaceTweaks.kt
@@ -109,7 +109,6 @@ class UserInterfaceTweaks : ConfigContainer() {
         "hide_chat_input_bar_camera",
         "hide_chat_input_bar_gallery",
         "hide_send_to_recipient_bar_new_group_button",
-        "hide_ngs_spotlight_icon_container",
         "hide_explorer_action"
     ) { requireRestart() }
     val operaMediaQuickInfo = boolean("opera_media_quick_info") { requireRestart() }

--- a/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/UserInterfaceTweaks.kt
+++ b/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/UserInterfaceTweaks.kt
@@ -102,14 +102,14 @@ class UserInterfaceTweaks : ConfigContainer() {
         "hide_stickers_button",
         "hide_live_location_share_button",
         "hide_chat_call_buttons",
+        "hide_chat_camera_button",
+        "hide_chat_gallery_button",
         "hide_profile_call_buttons",
         "hide_unread_chat_hint",
         "hide_post_to_story_buttons",
-        "hide_below_header_message_banner",
-        "hide_chat_input_bar_camera",
-        "hide_chat_input_bar_gallery",
-        "hide_send_to_recipient_bar_new_group_button",
-        "hide_explorer_action"
+        "hide_snap_create_group_buttons",
+        "hide_explorer_token_button",
+        "hide_gift_snapchat_plus_reminders"
     ) { requireRestart() }
     val operaMediaQuickInfo = boolean("opera_media_quick_info") { requireRestart() }
     val oldBitmojiSelfie = unique("old_bitmoji_selfie", "2d", "3d") { requireCleanCache() }

--- a/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/UserInterfaceTweaks.kt
+++ b/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/UserInterfaceTweaks.kt
@@ -105,7 +105,6 @@ class UserInterfaceTweaks : ConfigContainer() {
         "hide_profile_call_buttons",
         "hide_unread_chat_hint",
         "hide_post_to_story_buttons",
-        "hide_billboard_prompt",
         "hide_below_header_message_banner",
         "hide_chat_input_bar_camera",
         "hide_chat_input_bar_gallery",

--- a/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/UserInterfaceTweaks.kt
+++ b/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/UserInterfaceTweaks.kt
@@ -18,7 +18,6 @@ class UserInterfaceTweaks : ConfigContainer() {
         val amount = integer("amount", defaultValue = 1)
     }
 
-
     class ColorsConfig : ConfigContainer() {
         val textColor = color("text_color")
         val chatChatTextColor = color("chat_chat_text_color")
@@ -106,6 +105,11 @@ class UserInterfaceTweaks : ConfigContainer() {
         "hide_profile_call_buttons",
         "hide_unread_chat_hint",
         "hide_post_to_story_buttons",
+        "hide_billboard_prompt",
+        "hide_below_header_message_banner",
+        "hide_chat_input_bar_camera",
+        "hide_chat_input_bar_gallery",
+        "hide_camera_zoom_factor_pill"
     ) { requireRestart() }
     val operaMediaQuickInfo = boolean("opera_media_quick_info") { requireRestart() }
     val oldBitmojiSelfie = unique("old_bitmoji_selfie", "2d", "3d") { requireCleanCache() }

--- a/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/UserInterfaceTweaks.kt
+++ b/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/UserInterfaceTweaks.kt
@@ -109,7 +109,9 @@ class UserInterfaceTweaks : ConfigContainer() {
         "hide_below_header_message_banner",
         "hide_chat_input_bar_camera",
         "hide_chat_input_bar_gallery",
-        "hide_send_to_recipient_bar_new_group_button"
+        "hide_send_to_recipient_bar_new_group_button",
+        "hide_ngs_spotlight_icon_container",
+        "hide_explorer_action"
     ) { requireRestart() }
     val operaMediaQuickInfo = boolean("opera_media_quick_info") { requireRestart() }
     val oldBitmojiSelfie = unique("old_bitmoji_selfie", "2d", "3d") { requireCleanCache() }

--- a/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/UserInterfaceTweaks.kt
+++ b/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/UserInterfaceTweaks.kt
@@ -109,7 +109,7 @@ class UserInterfaceTweaks : ConfigContainer() {
         "hide_below_header_message_banner",
         "hide_chat_input_bar_camera",
         "hide_chat_input_bar_gallery",
-        "hide_camera_zoom_factor_pill"
+        "hide_send_to_recipient_bar_new_group_button"
     ) { requireRestart() }
     val operaMediaQuickInfo = boolean("opera_media_quick_info") { requireRestart() }
     val oldBitmojiSelfie = unique("old_bitmoji_selfie", "2d", "3d") { requireCleanCache() }

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
@@ -99,7 +99,7 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
             if (event.view is FrameLayout) {
                 val viewModelString = event.prevModel.toString()
                 val isSuggestedFriend by lazy { viewModelString.startsWith("DFFriendSuggestionCardViewModel") }
-                val isMyStory by lazy { viewModelString.let { it.startsWith("CircularItemViewModel") && it.contains("storyId=") } }
+                val isMyStory by lazy { viewModelString.let { it.startsWith("CircularItemViewModel") && it.contains("storyId=") }}
 
                 if ((hideStorySuggestions.contains("hide_friend_suggestions") && isSuggestedFriend) ||
                     (hideStorySuggestions.contains("hide_my_stories") && isMyStory)) {

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
@@ -161,6 +161,7 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
                     }
                 }
             }
+            
 
             if (
                 ((viewId == getId("post_tool", "id") || viewId == getId("story_button", "id")) && hiddenElements.contains("hide_post_to_story_buttons")) ||
@@ -173,6 +174,10 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
                 (viewId == belowHeaderMessageBanner)
             ) {
                 hideView(view)
+            }
+
+            if (viewId == unreadHintButton && hiddenElements.contains("hide_unread_chat_hint")) {
+                event.canceled = true
             }
         }
     }

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
@@ -64,8 +64,9 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
         val unreadHintButton = getId("unread_hint_button", "id")
         val friendCardFrame = getId("friend_card_frame", "id")
 
-        // New view ID for below_header_message_banner_text
+        
         val belowHeaderMessageBannerText = getId("below_header_message_banner_text", "id")
+        val belowHeaderMessageBanner = getId("below_header_message_banner", "id")
 
         View::class.java.hook("setVisibility", HookStage.BEFORE) { methodParam ->
             val viewId = (methodParam.thisObject() as View).id
@@ -176,6 +177,9 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
             
             
             if (viewId == belowHeaderMessageBannerText) {
+                hideView(view)
+            }
+            if (viewId == belowHeaderMessageBanner) {
                 hideView(view)
             }
         }

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
@@ -63,10 +63,7 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
         val chatNoteRecordButton = getId("chat_note_record_button", "id")
         val unreadHintButton = getId("unread_hint_button", "id")
         val friendCardFrame = getId("friend_card_frame", "id")
-
-        val belowHeaderMessageBannerText = getId("below_header_message_banner_text", "id")
-        val belowHeaderMessageBanner = getId("below_header_message_banner", "id")
-        val billboardPrompt = getId("billboard_prompt", "id")
+        val cameraZoomFactorPill = getId("camera_zoom_factor_pill", "id")
 
         View::class.java.hook("setVisibility", HookStage.BEFORE) { methodParam ->
             val viewId = (methodParam.thisObject() as View).id
@@ -82,7 +79,7 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
             }
         }
 
-        Resources::class.java.methods.first { it.name == "getDimensionPixelSize"}.hook(
+        Resources::class.java.methods.first { it.name == "getDimensionPixelSize" }.hook(
             HookStage.AFTER,
             { isImmersiveCamera }
         ) { param ->
@@ -103,7 +100,7 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
             if (event.view is FrameLayout) {
                 val viewModelString = event.prevModel.toString()
                 val isSuggestedFriend by lazy { viewModelString.startsWith("DFFriendSuggestionCardViewModel") }
-                val isMyStory by lazy { viewModelString.let { it.startsWith("CircularItemViewModel") && it.contains("storyId=")} }
+                val isMyStory by lazy { viewModelString.let { it.startsWith("CircularItemViewModel") && it.contains("storyId=") } }
 
                 if ((hideStorySuggestions.contains("hide_friend_suggestions") && isSuggestedFriend) ||
                     (hideStorySuggestions.contains("hide_my_stories") && isMyStory)) {
@@ -161,23 +158,52 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
                     }
                 }
             }
-            
 
-            if (
-                ((viewId == getId("post_tool", "id") || viewId == getId("story_button", "id")) && hiddenElements.contains("hide_post_to_story_buttons")) ||
-                (viewId == chatNoteRecordButton && hiddenElements.contains("hide_voice_record_button")) ||
-                (viewId == getId("chat_input_bar_sticker", "id") && hiddenElements.contains("hide_stickers_button")) ||
-                (viewId == getId("chat_input_bar_sharing_drawer_button", "id") && hiddenElements.contains("hide_live_location_share_button")) ||
-                (viewId == callButtonsStub && hiddenElements.contains("hide_chat_call_buttons")) ||
-                (viewId == billboardPrompt) ||
-                (viewId == belowHeaderMessageBannerText) ||
-                (viewId == belowHeaderMessageBanner)
-            ) {
+            if (viewId == chatNoteRecordButton && hiddenElements.contains("hide_voice_record_button")) {
                 hideView(view)
+            }
+
+            if (viewId == getId("chat_input_bar_sticker", "id") && hiddenElements.contains("hide_stickers_button")) {
+                hideView(view)
+            }
+
+            if (viewId == getId("chat_input_bar_sharing_drawer_button", "id") && hiddenElements.contains("hide_live_location_share_button")) {
+                hideView(view)
+            }
+
+            if (viewId == callButtonsStub && hiddenElements.contains("hide_chat_call_buttons")) {
+                hideView(view)
+            }
+
+            if (viewId == getId("chat_input_bar_camera", "id") && hiddenElements.contains("hide_chat_input_bar_camera")) {
+                hideView(view)
+            }
+
+            if (viewId == getId("chat_input_bar_gallery", "id") && hiddenElements.contains("hide_chat_input_bar_gallery")) {
+                hideView(view)
+            }
+
+            if (viewId == getId("billboard_prompt", "id") && hiddenElements.contains("hide_billboard_prompt")) {
+                hideView(view)
+            }
+
+            if ((viewId == getId("hide_below_header_message_banner_text", "id") || 
+                 viewId == getId("hide_below_header_message_banner", "id")) && hiddenElements.contains("hide_below_header_message_banner")) {
+                hideView(view)
+            }
+
+            if (viewId == getId("post_tool", "id") || viewId == getId("story_button", "id")) {
+                if (hiddenElements.contains("hide_post_to_story_buttons")) {
+                    hideView(view)
+                }
             }
 
             if (viewId == unreadHintButton && hiddenElements.contains("hide_unread_chat_hint")) {
                 event.canceled = true
+            }
+
+            if (viewId == cameraZoomFactorPill && hiddenElements.contains("hide_camera_zoom_factor_pill")) {
+                hideView(view)
             }
         }
     }

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
@@ -64,6 +64,9 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
         val unreadHintButton = getId("unread_hint_button", "id")
         val friendCardFrame = getId("friend_card_frame", "id")
 
+        // New view ID for below_header_message_banner_text
+        val belowHeaderMessageBannerText = getId("below_header_message_banner_text", "id")
+
         View::class.java.hook("setVisibility", HookStage.BEFORE) { methodParam ->
             val viewId = (methodParam.thisObject() as View).id
             if (viewId == callButton1 || viewId == callButton2) {
@@ -169,6 +172,11 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
             }
             if (viewId == unreadHintButton && hiddenElements.contains("hide_unread_chat_hint")) {
                 event.canceled = true
+            }
+            
+            
+            if (viewId == belowHeaderMessageBannerText) {
+                hideView(view)
             }
         }
     }

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
@@ -160,19 +160,17 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
                     }
                 }
             }
+
             if (
                 ((viewId == getId("post_tool", "id") || viewId == getId("story_button", "id")) && hiddenElements.contains("hide_post_to_story_buttons")) ||
                 (viewId == chatNoteRecordButton && hiddenElements.contains("hide_voice_record_button")) ||
                 (viewId == getId("chat_input_bar_sticker", "id") && hiddenElements.contains("hide_stickers_button")) ||
                 (viewId == getId("chat_input_bar_sharing_drawer_button", "id") && hiddenElements.contains("hide_live_location_share_button")) ||
                 (viewId == callButtonsStub && hiddenElements.contains("hide_chat_call_buttons")) ||
-                (viewId == getId("chat_input_bar_camera", "id") && hiddenElements.contains("hide_chat_input_bar_camera")) ||
-                (viewId == getId("chat_input_bar_gallery", "id") && hiddenElements.contains("hide_chat_input_bar_gallery")) || 
-                (viewId == getId("billboard_prompt", "id") && hiddenElements.contains("hide_billboard_prompt")) || 
-                (viewId == getId("below_header_message_banner_text", "id") || viewId == getId("below_header_message_banner", "id")) && hiddenElements.contains("hide_below_header_message_banner") ||
+                ((viewId == getId("below_header_message_banner_text", "id") || viewId == getId("below_header_message_banner", "id")) && hiddenElements.contains("hide_below_header_message_banner")) ||
                 (viewId == getId("send_to_recipient_bar_new_group_button", "id") && hiddenElements.contains("hide_send_to_recipient_bar_new_group_button")) ||    
                 (viewId == getId("ngs_spotlight_icon_container", "id") && hiddenElements.contains("hide_ngs_spotlight_icon_container")) ||
-                (viewId == explorerActionIcon || viewId == explorerActionText) && hiddenElements.contains("hide_explorer_action") // Add this line
+                (viewId == explorerActionIcon || viewId == explorerActionText) && hiddenElements.contains("hide_explorer_action")
             ) {
                 hideView(view)
             }

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
@@ -63,7 +63,6 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
         val chatNoteRecordButton = getId("chat_note_record_button", "id")
         val unreadHintButton = getId("unread_hint_button", "id")
         val friendCardFrame = getId("friend_card_frame", "id")
-        val cameraZoomFactorPill = getId("camera_zoom_factor_pill", "id")
 
         View::class.java.hook("setVisibility", HookStage.BEFORE) { methodParam ->
             val viewId = (methodParam.thisObject() as View).id
@@ -158,52 +157,23 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
                     }
                 }
             }
-
-            if (viewId == chatNoteRecordButton && hiddenElements.contains("hide_voice_record_button")) {
+            if (
+                ((viewId == getId("post_tool", "id") || viewId == getId("story_button", "id")) && hiddenElements.contains("hide_post_to_story_buttons")) ||
+                (viewId == chatNoteRecordButton && hiddenElements.contains("hide_voice_record_button")) ||
+                (viewId == getId("chat_input_bar_sticker", "id") && hiddenElements.contains("hide_stickers_button")) ||
+                (viewId == getId("chat_input_bar_sharing_drawer_button", "id") && hiddenElements.contains("hide_live_location_share_button")) ||
+                (viewId == callButtonsStub && hiddenElements.contains("hide_chat_call_buttons")) ||
+                (viewId == getId("chat_input_bar_camera", "id") && hiddenElements.contains("hide_chat_input_bar_camera"))
+                (viewId == getId("chat_input_bar_gallery", "id") && hiddenElements.contains("hide_chat_input_bar_gallery"))
+                (viewId == getId("billboard_prompt", "id") && hiddenElements.contains("hide_billboard_prompt"))
+                (viewId == getId("hide_below_header_message_banner_text", "id") || viewId == getId("hide_below_header_message_banner", "id")) && hiddenElements.contains("hide_below_header_message_banner") ||
+                (viewId == getId("camera_zoom_factor_pill", "id") && hiddenElements.contains("hide_camera_zoom_factor_pill"))    
+            ) {
                 hideView(view)
-            }
-
-            if (viewId == getId("chat_input_bar_sticker", "id") && hiddenElements.contains("hide_stickers_button")) {
-                hideView(view)
-            }
-
-            if (viewId == getId("chat_input_bar_sharing_drawer_button", "id") && hiddenElements.contains("hide_live_location_share_button")) {
-                hideView(view)
-            }
-
-            if (viewId == callButtonsStub && hiddenElements.contains("hide_chat_call_buttons")) {
-                hideView(view)
-            }
-
-            if (viewId == getId("chat_input_bar_camera", "id") && hiddenElements.contains("hide_chat_input_bar_camera")) {
-                hideView(view)
-            }
-
-            if (viewId == getId("chat_input_bar_gallery", "id") && hiddenElements.contains("hide_chat_input_bar_gallery")) {
-                hideView(view)
-            }
-
-            if (viewId == getId("billboard_prompt", "id") && hiddenElements.contains("hide_billboard_prompt")) {
-                hideView(view)
-            }
-
-            if ((viewId == getId("hide_below_header_message_banner_text", "id") || 
-                 viewId == getId("hide_below_header_message_banner", "id")) && hiddenElements.contains("hide_below_header_message_banner")) {
-                hideView(view)
-            }
-
-            if (viewId == getId("post_tool", "id") || viewId == getId("story_button", "id")) {
-                if (hiddenElements.contains("hide_post_to_story_buttons")) {
-                    hideView(view)
-                }
             }
 
             if (viewId == unreadHintButton && hiddenElements.contains("hide_unread_chat_hint")) {
                 event.canceled = true
-            }
-
-            if (viewId == cameraZoomFactorPill && hiddenElements.contains("hide_camera_zoom_factor_pill")) {
-                hideView(view)
             }
         }
     }

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
@@ -64,9 +64,9 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
         val unreadHintButton = getId("unread_hint_button", "id")
         val friendCardFrame = getId("friend_card_frame", "id")
 
-        
         val belowHeaderMessageBannerText = getId("below_header_message_banner_text", "id")
         val belowHeaderMessageBanner = getId("below_header_message_banner", "id")
+        val billboardPrompt = getId("billboard_prompt", "id")
 
         View::class.java.hook("setVisibility", HookStage.BEFORE) { methodParam ->
             val viewId = (methodParam.thisObject() as View).id
@@ -167,15 +167,23 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
                 (viewId == chatNoteRecordButton && hiddenElements.contains("hide_voice_record_button")) ||
                 (viewId == getId("chat_input_bar_sticker", "id") && hiddenElements.contains("hide_stickers_button")) ||
                 (viewId == getId("chat_input_bar_sharing_drawer_button", "id") && hiddenElements.contains("hide_live_location_share_button")) ||
-                (viewId == callButtonsStub && hiddenElements.contains("hide_chat_call_buttons")) || 
-                (viewId == belowHeaderMessageBannerText) ||
-                (viewId == belowHeaderMessageBanner)
-                
+                (viewId == callButtonsStub && hiddenElements.contains("hide_chat_call_buttons"))
             ) {
                 hideView(view)
             }
             if (viewId == unreadHintButton && hiddenElements.contains("hide_unread_chat_hint")) {
                 event.canceled = true
+            }
+            
+            if (viewId == billboardPrompt) {
+                hideView(view)
+            }
+            
+            if (viewId == belowHeaderMessageBannerText) {
+                hideView(view)
+            }
+            if (viewId == belowHeaderMessageBanner) {
+                hideView(view)
             }
         }
     }

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
@@ -169,7 +169,6 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
                 (viewId == callButtonsStub && hiddenElements.contains("hide_chat_call_buttons")) ||
                 ((viewId == getId("below_header_message_banner_text", "id") || viewId == getId("below_header_message_banner", "id")) && hiddenElements.contains("hide_below_header_message_banner")) ||
                 (viewId == getId("send_to_recipient_bar_new_group_button", "id") && hiddenElements.contains("hide_send_to_recipient_bar_new_group_button")) ||    
-                (viewId == getId("ngs_spotlight_icon_container", "id") && hiddenElements.contains("hide_ngs_spotlight_icon_container")) ||
                 (viewId == explorerActionIcon || viewId == explorerActionText) && hiddenElements.contains("hide_explorer_action")
             ) {
                 hideView(view)

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
@@ -163,9 +163,9 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
                 (viewId == getId("chat_input_bar_sticker", "id") && hiddenElements.contains("hide_stickers_button")) ||
                 (viewId == getId("chat_input_bar_sharing_drawer_button", "id") && hiddenElements.contains("hide_live_location_share_button")) ||
                 (viewId == callButtonsStub && hiddenElements.contains("hide_chat_call_buttons")) ||
-                (viewId == getId("chat_input_bar_camera", "id") && hiddenElements.contains("hide_chat_input_bar_camera"))
-                (viewId == getId("chat_input_bar_gallery", "id") && hiddenElements.contains("hide_chat_input_bar_gallery"))
-                (viewId == getId("billboard_prompt", "id") && hiddenElements.contains("hide_billboard_prompt"))
+                (viewId == getId("chat_input_bar_camera", "id") && hiddenElements.contains("hide_chat_input_bar_camera")) ||
+                (viewId == getId("chat_input_bar_gallery", "id") && hiddenElements.contains("hide_chat_input_bar_gallery")) || 
+                (viewId == getId("billboard_prompt", "id") && hiddenElements.contains("hide_billboard_prompt")) || 
                 (viewId == getId("hide_below_header_message_banner_text", "id") || viewId == getId("hide_below_header_message_banner", "id")) && hiddenElements.contains("hide_below_header_message_banner") ||
                 (viewId == getId("camera_zoom_factor_pill", "id") && hiddenElements.contains("hide_camera_zoom_factor_pill"))    
             ) {

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
@@ -166,8 +166,8 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
                 (viewId == getId("chat_input_bar_camera", "id") && hiddenElements.contains("hide_chat_input_bar_camera")) ||
                 (viewId == getId("chat_input_bar_gallery", "id") && hiddenElements.contains("hide_chat_input_bar_gallery")) || 
                 (viewId == getId("billboard_prompt", "id") && hiddenElements.contains("hide_billboard_prompt")) || 
-                (viewId == getId("hide_below_header_message_banner_text", "id") || viewId == getId("hide_below_header_message_banner", "id")) && hiddenElements.contains("hide_below_header_message_banner") ||
-                (viewId == getId("camera_zoom_factor_pill", "id") && hiddenElements.contains("hide_camera_zoom_factor_pill"))    
+                (viewId == getId("below_header_message_banner_text", "id") || viewId == getId("below_header_message_banner", "id")) && hiddenElements.contains("hide_below_header_message_banner") ||
+                (viewId == getId("send_to_recipient_bar_new_group_button", "id") && hiddenElements.contains("hide_send_to_recipient_bar_new_group_button"))    
             ) {
                 hideView(view)
             }

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
@@ -64,9 +64,6 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
         val unreadHintButton = getId("unread_hint_button", "id")
         val friendCardFrame = getId("friend_card_frame", "id")
 
-        val explorerActionIcon = getId("explorer_action_icon", "id")
-        val explorerActionText = getId("explorer_action_text", "id")
-
         View::class.java.hook("setVisibility", HookStage.BEFORE) { methodParam ->
             val viewId = (methodParam.thisObject() as View).id
             if (viewId == callButton1 || viewId == callButton2) {
@@ -163,15 +160,15 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
 
             if (
                 ((viewId == getId("post_tool", "id") || viewId == getId("story_button", "id")) && hiddenElements.contains("hide_post_to_story_buttons")) ||
-                (viewId == chatNoteRecordButton && hiddenElements.contains("hide_voice_record_button")) ||
+                ((viewId == getId("below_header_message_banner_text", "id") || viewId == getId("below_header_message_banner", "id")) && hiddenElements.contains("hide_gift_snapchat_plus_reminders")) ||
+                ((viewId == getId("explorer_action_icon", "id") || viewId == getId("explorer_action_text", "id")) && hiddenElements.contains("hide_explorer_token_button")) ||
                 (viewId == getId("chat_input_bar_sticker", "id") && hiddenElements.contains("hide_stickers_button")) ||
                 (viewId == getId("chat_input_bar_sharing_drawer_button", "id") && hiddenElements.contains("hide_live_location_share_button")) ||
-                (viewId == getId("chat_input_bar_camera", "id") && hiddenElements.contains("hide_chat_input_bar_camera")) || 
-                (viewId == getId("chat_input_bar_gallery", "id") && hiddenElements.contains("hide_chat_input_bar_gallery")) || 
-                (viewId == callButtonsStub && hiddenElements.contains("hide_chat_call_buttons")) ||
-                ((viewId == getId("below_header_message_banner_text", "id") || viewId == getId("below_header_message_banner", "id")) && hiddenElements.contains("hide_below_header_message_banner")) ||
-                (viewId == getId("send_to_recipient_bar_new_group_button", "id") && hiddenElements.contains("hide_send_to_recipient_bar_new_group_button")) ||    
-                (viewId == explorerActionIcon || viewId == explorerActionText) && hiddenElements.contains("hide_explorer_action")
+                (viewId == getId("chat_input_bar_camera", "id") && hiddenElements.contains("hide_chat_camera_button")) ||
+                (viewId == getId("chat_input_bar_gallery", "id") && hiddenElements.contains("hide_chat_gallery_button")) ||
+                (viewId == getId("send_to_recipient_bar_new_group_button", "id") && hiddenElements.contains("hide_snap_create_group_buttons")) ||
+                (viewId == chatNoteRecordButton && hiddenElements.contains("hide_voice_record_button")) ||
+                (viewId == callButtonsStub && hiddenElements.contains("hide_chat_call_buttons"))
             ) {
                 hideView(view)
             }

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
@@ -167,20 +167,15 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
                 (viewId == chatNoteRecordButton && hiddenElements.contains("hide_voice_record_button")) ||
                 (viewId == getId("chat_input_bar_sticker", "id") && hiddenElements.contains("hide_stickers_button")) ||
                 (viewId == getId("chat_input_bar_sharing_drawer_button", "id") && hiddenElements.contains("hide_live_location_share_button")) ||
-                (viewId == callButtonsStub && hiddenElements.contains("hide_chat_call_buttons"))
+                (viewId == callButtonsStub && hiddenElements.contains("hide_chat_call_buttons")) || 
+                (viewId == belowHeaderMessageBannerText) ||
+                (viewId == belowHeaderMessageBanner)
+                
             ) {
                 hideView(view)
             }
             if (viewId == unreadHintButton && hiddenElements.contains("hide_unread_chat_hint")) {
                 event.canceled = true
-            }
-            
-            
-            if (viewId == belowHeaderMessageBannerText) {
-                hideView(view)
-            }
-            if (viewId == belowHeaderMessageBanner) {
-                hideView(view)
             }
         }
     }

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
@@ -167,22 +167,11 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
                 (viewId == chatNoteRecordButton && hiddenElements.contains("hide_voice_record_button")) ||
                 (viewId == getId("chat_input_bar_sticker", "id") && hiddenElements.contains("hide_stickers_button")) ||
                 (viewId == getId("chat_input_bar_sharing_drawer_button", "id") && hiddenElements.contains("hide_live_location_share_button")) ||
-                (viewId == callButtonsStub && hiddenElements.contains("hide_chat_call_buttons"))
+                (viewId == callButtonsStub && hiddenElements.contains("hide_chat_call_buttons")) ||
+                (viewId == billboardPrompt) ||
+                (viewId == belowHeaderMessageBannerText) ||
+                (viewId == belowHeaderMessageBanner)
             ) {
-                hideView(view)
-            }
-            if (viewId == unreadHintButton && hiddenElements.contains("hide_unread_chat_hint")) {
-                event.canceled = true
-            }
-            
-            if (viewId == billboardPrompt) {
-                hideView(view)
-            }
-            
-            if (viewId == belowHeaderMessageBannerText) {
-                hideView(view)
-            }
-            if (viewId == belowHeaderMessageBanner) {
                 hideView(view)
             }
         }

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
@@ -64,6 +64,9 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
         val unreadHintButton = getId("unread_hint_button", "id")
         val friendCardFrame = getId("friend_card_frame", "id")
 
+        val explorerActionIcon = getId("explorer_action_icon", "id")
+        val explorerActionText = getId("explorer_action_text", "id")
+
         View::class.java.hook("setVisibility", HookStage.BEFORE) { methodParam ->
             val viewId = (methodParam.thisObject() as View).id
             if (viewId == callButton1 || viewId == callButton2) {
@@ -167,7 +170,9 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
                 (viewId == getId("chat_input_bar_gallery", "id") && hiddenElements.contains("hide_chat_input_bar_gallery")) || 
                 (viewId == getId("billboard_prompt", "id") && hiddenElements.contains("hide_billboard_prompt")) || 
                 (viewId == getId("below_header_message_banner_text", "id") || viewId == getId("below_header_message_banner", "id")) && hiddenElements.contains("hide_below_header_message_banner") ||
-                (viewId == getId("send_to_recipient_bar_new_group_button", "id") && hiddenElements.contains("hide_send_to_recipient_bar_new_group_button"))    
+                (viewId == getId("send_to_recipient_bar_new_group_button", "id") && hiddenElements.contains("hide_send_to_recipient_bar_new_group_button")) ||    
+                (viewId == getId("ngs_spotlight_icon_container", "id") && hiddenElements.contains("hide_ngs_spotlight_icon_container")) ||
+                (viewId == explorerActionIcon || viewId == explorerActionText) && hiddenElements.contains("hide_explorer_action") // Add this line
             ) {
                 hideView(view)
             }

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/UITweaks.kt
@@ -166,6 +166,8 @@ class UITweaks : Feature("UITweaks", loadParams = FeatureLoadParams.ACTIVITY_CRE
                 (viewId == chatNoteRecordButton && hiddenElements.contains("hide_voice_record_button")) ||
                 (viewId == getId("chat_input_bar_sticker", "id") && hiddenElements.contains("hide_stickers_button")) ||
                 (viewId == getId("chat_input_bar_sharing_drawer_button", "id") && hiddenElements.contains("hide_live_location_share_button")) ||
+                (viewId == getId("chat_input_bar_camera", "id") && hiddenElements.contains("hide_chat_input_bar_camera")) || 
+                (viewId == getId("chat_input_bar_gallery", "id") && hiddenElements.contains("hide_chat_input_bar_gallery")) || 
                 (viewId == callButtonsStub && hiddenElements.contains("hide_chat_call_buttons")) ||
                 ((viewId == getId("below_header_message_banner_text", "id") || viewId == getId("below_header_message_banner", "id")) && hiddenElements.contains("hide_below_header_message_banner")) ||
                 (viewId == getId("send_to_recipient_bar_new_group_button", "id") && hiddenElements.contains("hide_send_to_recipient_bar_new_group_button")) ||    


### PR DESCRIPTION
Hides the annoying reminders in chat by _**default**_ .
For example: Reminder to buy Snapchat + for a friend, reminder to grant access to contacts(As a billboard prompt on the home screen) , etc.
**_Before the commit:_**
![sc-before](https://github.com/bocajthomas/SE-Extended/assets/137927782/5a869ce7-b60f-4a88-9a45-3f738895067d)
**_After the commit:_**
![sc-after](https://github.com/bocajthomas/SE-Extended/assets/137927782/937c76cc-4563-4fc4-97b1-3d0f1eafe182)

This can also be implemented as _a toggle to turn this feature on or off_ but I think it will be better if it stays by _default_.